### PR TITLE
M3: Bridge refactoring - fix protocol bugs and update opcodes

### DIFF
--- a/quire-design.md
+++ b/quire-design.md
@@ -1598,7 +1598,7 @@ Bridge test coverage expands incrementally: M2–M4 each add tests for the bridg
   - Remove `initApp`, export `initBridge`
   - Result: bridge compiles and runs but has old op codes
 
-- [ ] **M3: Bridge refactoring — fix bugs + align protocol**
+- [x] **M3: Bridge refactoring — fix bugs + align protocol**
   - Fix diff entry stride overlap (§2.2, Bug 1): change to 16-byte stride
   - Fix OP_SET_ATTR placeholder (§2.2, Bug 2)
   - Update op codes: SET_TRANSFORM, CREATE_ELEMENT, SET_INNER_HTML, simplified SET_TEXT (§2.3.2–§2.3.6)


### PR DESCRIPTION
## Summary
This PR completes M3 of the bridge implementation by fixing critical bugs in the diff protocol and updating operation codes to align with the design specification. The changes fix a diff entry stride overlap bug, implement the OP_SET_ATTR placeholder, and introduce new opcodes for transform, element creation, and innerHTML operations.

## Key Changes

### Protocol Fixes
- **Fixed diff entry stride overlap (Bug 1)**: Changed from 12-byte to 16-byte stride with 4-byte aligned fields to prevent data corruption when reading multiple diffs
- **Fixed OP_SET_ATTR implementation (Bug 2)**: Replaced placeholder with proper attribute setting/removal logic that reads name and value from string buffer

### Updated Operation Codes
- `OP_SET_STYLE` → `OP_SET_TRANSFORM`: Now applies CSS transforms with x,y coordinates (reinterpreted as int32)
- `OP_ADD_CHILD` → `OP_CREATE_ELEMENT`: Creates elements with specified tag names instead of hardcoded divs
- `OP_NEED_FETCH` → `OP_SET_INNER_HTML`: Sets innerHTML from fetch buffer with offset/length parameters
- `OP_SET_TEXT`: Simplified to use offset/length from fetch buffer instead of complex conditional logic

### Implementation Details
- Diff buffer entries now use consistent 16-byte stride: op (4B) + nodeId (4B) + value1 (4B) + value2 (4B)
- String buffer and fetch buffer now properly support offset-based reads for all operations
- OP_CREATE_ELEMENT properly registers created nodes and maintains nextNodeId counter
- Added test helpers (`_initForTest`, `_applyDiffs`, `_clearNodeRegistry`) for unit testing without full WASM initialization

### Test Coverage
- Comprehensive test suite covering all 6 operation types
- Tests for edge cases: negative transforms, multi-byte UTF-8 attributes, missing parents, buffer offsets
- Tests for multiple sequential diffs and 16-byte stride correctness
- All tests pass with mock WASM module

## Design Document
Updated `quire-design.md` to mark M3 as complete.

https://claude.ai/code/session_01CYZA9tX1aNvFiznjGTAzS8