### PR TITLE
M8: Bridge IndexedDB imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "quire",
       "version": "0.1.0",
       "devDependencies": {
+        "fake-indexeddb": "^6.2.5",
         "jsdom": "^24.0.0",
         "serve": "^14.2.0",
         "vitest": "^1.6.0"
@@ -1896,6 +1897,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "serve": "serve ."
   },
   "devDependencies": {
+    "fake-indexeddb": "^6.2.5",
     "jsdom": "^24.0.0",
     "serve": "^14.2.0",
     "vitest": "^1.6.0"

--- a/quire-design.md
+++ b/quire-design.md
@@ -1622,7 +1622,7 @@ Bridge test coverage expands incrementally: M2–M4 each add tests for the bridg
   - Add `js_set_inner_html_from_blob` (§2.3.10)
   - Bridge-only PR — no app logic
 
-- [ ] **M8: Bridge IndexedDB imports**
+- [x] **M8: Bridge IndexedDB imports**
   - Add `js_kv_open`, `js_kv_put`, `js_kv_put_blob`, `js_kv_get`, `js_kv_delete` (§2.3.9)
   - Bridge-only PR
 

--- a/test/mock-wasm.js
+++ b/test/mock-wasm.js
@@ -39,6 +39,7 @@ export function createMockWasm() {
     on_timer_complete: [],
     on_file_open_complete: [],
     on_decompress_complete: [],
+    on_kv_open_complete: [],
     on_kv_complete: [],
     on_kv_get_complete: [],
     on_kv_get_blob_complete: [],
@@ -95,6 +96,10 @@ export function createMockWasm() {
 
     on_decompress_complete(handle, size) {
       callbacks.on_decompress_complete.push({ handle, size });
+    },
+
+    on_kv_open_complete(success) {
+      callbacks.on_kv_open_complete.push({ success });
     },
 
     on_kv_complete(success) {


### PR DESCRIPTION
Add generic key-value store over IndexedDB for WASM apps:
- js_kv_open: Opens database with object store creation
- js_kv_put: Stores data from fetch buffer
- js_kv_put_blob: Stores data from blob handle
- js_kv_get: Retrieves data (small to fetch buffer, large to blob)
- js_kv_delete: Removes keys
- js_kv_close: Closes database connection

Added fake-indexeddb for testing IndexedDB operations in Node.

https://claude.ai/code/session_01X8xRot2v7UUKkBRhUSgNtk