### PR TITLE
Add GitHub Pages deployment to CI/CD pipeline

### DIFF
--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -58,3 +58,25 @@ jobs:
           name: quire-pwa
           path: dist/
           retention-days: 90
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist/
+
+  deploy:
+    needs: package
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 PWA e-reader with all application logic in ATS2 compiled to WASM.
 
+**Live demo:** https://moshez.github.io/quire/
+
 ## Prerequisites
 
 ### ATS2 (ATS/Postiats)

--- a/quire-design.md
+++ b/quire-design.md
@@ -1877,6 +1877,6 @@ jobs:
 
 **Why pin the ATS-Postiats commit?** ATS2 development is active and occasionally introduces breaking changes in codegen. Pinning to a known-good commit prevents mysterious CI failures unrelated to Quire changes. Bumping the pin is a one-line change in both workflow files (via the shared `ATS_COMMIT` env var).
 
-**Why not deploy to Pages?** The `upload.yaml` workflow deliberately stops at artifact upload rather than deploying to GitHub Pages. Deployment target is a separate decision — could be Pages, Cloudflare, Netlify, or a custom server. The artifact is the universal intermediate: download it and put it wherever you want. A deployment step can be added later as a third workflow or appended to this one.
+**GitHub Pages deployment:** The `upload.yaml` workflow both uploads an artifact and deploys to GitHub Pages. The artifact remains available as a universal intermediate for alternative deployment targets (Cloudflare, Netlify, custom servers).
 
 **Artifact retention** is set to 90 days. Older builds can always be regenerated from the corresponding commit.


### PR DESCRIPTION
## Summary
This PR adds automatic deployment to GitHub Pages as part of the CI/CD pipeline, making the built PWA accessible at https://moshez.github.io/quire/. The artifact upload step is retained to support alternative deployment targets.

## Changes
- **CI/CD Pipeline**: Extended `upload.yaml` workflow with GitHub Pages deployment steps
  - Added `actions/configure-pages@v4` to setup Pages environment
  - Added `actions/upload-pages-artifact@v3` to prepare artifact for deployment
  - Created new `deploy` job that depends on `package` job
  - Configured appropriate permissions (`pages: write`, `id-token: write`)
  - Deployed using `actions/deploy-pages@v4`

- **Documentation**: Updated README and design doc
  - Added live demo link to README pointing to the GitHub Pages deployment
  - Updated `quire-design.md` to reflect that Pages deployment is now enabled while maintaining artifact availability for alternative targets

## Implementation Details
- The deployment is configured as a separate job (`deploy`) that depends on the `package` job, following GitHub Actions best practices
- GitHub Pages environment is explicitly configured with the deployment URL output
- The artifact upload step remains in the `package` job, preserving the ability to download builds for alternative deployment scenarios
- 90-day artifact retention policy is maintained

https://claude.ai/code/session_01QPCrt5jNzXHVbtVUHkVBU9