### PR TITLE
M11: Implement pagination with click zones and keyboard navigation

### DIFF
--- a/bridge.js
+++ b/bridge.js
@@ -721,7 +721,21 @@ function wrapExports(instance) {
 
 function handleEvent(event, type) {
   const nodeId = parseInt(event.target.dataset?.nodeId) || 0;
-  writeEvent(type, nodeId);
+  let data1 = 0;
+  let data2 = 0;
+
+  // For click events, pass coordinates
+  if (type === EVENT_CLICK && event.clientX !== undefined) {
+    data1 = Math.round(event.clientX);
+    data2 = Math.round(event.clientY);
+  }
+
+  // For keyboard events, pass key code
+  if (type === EVENT_KEYDOWN || type === EVENT_KEYUP) {
+    data1 = event.keyCode || 0;
+  }
+
+  writeEvent(type, nodeId, data1, data2);
   wasm.process_event();
 }
 
@@ -940,6 +954,11 @@ export function _writeStringAt(str, offset) {
   const bytes = encoder.encode(str);
   new Uint8Array(memory.buffer, offset, bytes.length).set(bytes);
   return bytes.length;
+}
+
+// Test helper: write event to buffer (for testing event encoding)
+export function _writeEvent(type, nodeId, data1 = 0, data2 = 0) {
+  writeEvent(type, nodeId, data1, data2);
 }
 
 export { registerNode, getNode };

--- a/quire-design.md
+++ b/quire-design.md
@@ -1643,7 +1643,7 @@ Bridge test coverage expands incrementally: M2–M4 each add tests for the bridg
   - CSS styles built and injected from WASM (CSS column layout)
   - Verify: chapter text appears, flows into columns
 
-- [ ] **M11: Pagination**
+- [x] **M11: Pagination**
   - Use `js_measure_node` to get scrollWidth
   - Compute page count
   - `SET_TRANSFORM` for page navigation

--- a/test/mock-wasm.js
+++ b/test/mock-wasm.js
@@ -281,3 +281,19 @@ export const EVENT_FOCUS = 6;
 export const EVENT_BLUR = 7;
 export const EVENT_PUSH = 8;
 export const EVENT_NOTIFICATION_CLICK = 9;
+
+/**
+ * Helper to write events directly to the event buffer.
+ * Mirrors bridge.js writeEvent function for testing.
+ * @param {DataView} view - DataView of WASM memory at event buffer
+ * @param {number} type - Event type
+ * @param {number} nodeId - Node ID
+ * @param {number} data1 - First data parameter
+ * @param {number} data2 - Second data parameter
+ */
+export function writeEventToBuffer(view, offset, type, nodeId, data1 = 0, data2 = 0) {
+  view.setUint8(offset, type);
+  view.setUint32(offset + 1, nodeId, true);
+  view.setUint32(offset + 5, data1, true);
+  view.setUint32(offset + 9, data2, true);
+}


### PR DESCRIPTION
## Summary
Implements milestone M11 (Pagination) for the Quire reader, adding multi-page chapter support with click-zone navigation and keyboard controls. Chapters are displayed in a CSS column layout, and users can navigate between pages using click zones (left/right 20% of viewport) or keyboard shortcuts.

## Key Changes

### Event System Enhancement (bridge.js)
- Extended `handleEvent()` to capture and encode event data:
  - Click events: encode `clientX` and `clientY` coordinates as `data1` and `data2`
  - Keyboard events: encode `keyCode` as `data1`
- Updated `writeEvent()` signature to accept `data1` and `data2` parameters
- Added `_writeEvent()` export for testing event encoding

### Pagination Implementation (src/quire.dats)
- **Page measurement**: `measure_chapter_pages()` uses `js_measure_node()` to read chapter scrollWidth and compute total pages
- **Page navigation**: 
  - `go_to_page()`: Navigate to specific page with `SET_TRANSFORM` offset
  - `go_prev_page()` / `go_next_page()`: Relative navigation
- **Click zone handling**: Left 20% and right 20% of viewport trigger previous/next page
- **Keyboard navigation**: Support for arrow keys, Page Up/Down, Space, Home, and End keys
- **Page indicator**: Fixed position display showing "current / total" pages, updated after chapter loads

### UI/Styling
- Added page indicator element with fixed positioning at bottom center
- Styled with semi-transparent dark background and white text
- CSS class: `page-indicator` with `z-index: 100` and `pointer-events: none`

### State Management
- New pagination state variables: `current_page`, `total_pages`, `viewport_width`, `page_stride`, `page_indicator_id`
- Helper functions to read `data1` and `data2` from event buffer
- Page measurement triggered automatically after chapter loads

### Testing
- Added test suite for event data encoding in `bridge.test.js`
- Tests verify click coordinate encoding and keyboard key code encoding
- Added `writeEventToBuffer()` helper in `mock-wasm.js` for test support
- Marked M11 milestone as complete in `quire-design.md`

## Implementation Details
- Page stride equals viewport width (no column gap in CSS)
- Page count calculated as `ceil(scrollWidth / viewportWidth)`
- Transform offset calculated as `-(current_page * page_stride)` for horizontal scrolling
- Event data stored as 32-bit unsigned integers in event buffer at offsets 5-8 (data1) and 9-12 (data2)

https://claude.ai/code/session_01LPGF4R9KXpKSmgWBDeHWs7