### PR TITLE
Make reader.css optional in build distribution step

### DIFF
--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -45,7 +45,7 @@ jobs:
           mkdir -p dist
           cp index.html dist/
           cp bridge.js dist/
-          cp reader.css dist/
+          cp reader.css dist/ 2>/dev/null || true
           cp manifest.json dist/
           cp service-worker.js dist/ 2>/dev/null || true
           cp build/quire.wasm dist/


### PR DESCRIPTION
## Summary
Updated the build workflow to gracefully handle cases where `reader.css` may not exist, preventing build failures when the file is missing.

## Changes
- Modified the `reader.css` copy command in the upload workflow to suppress errors if the file doesn't exist
- Added `2>/dev/null || true` to the copy command, making it non-fatal if the file is absent
- This brings the `reader.css` handling in line with other optional files like `service-worker.js`

## Details
The change allows the build process to continue even if `reader.css` is not present in the repository, while still copying it when available. This is consistent with how `service-worker.js` is already handled in the same workflow.

https://claude.ai/code/session_016YV31fAHNmfZwbAbFXU4Nk