### PR TITLE
Handle deflate-compressed EPUB metadata via async decompression

### DIFF
--- a/e2e/create-epub.js
+++ b/e2e/create-epub.js
@@ -224,7 +224,7 @@ ${spineItems}  </spine>
 
   // Assemble ZIP entries
   // mimetype MUST be first and stored (EPUB spec)
-  // container.xml and content.opf MUST be stored (WASM parser reads them synchronously)
+  // container.xml and content.opf are stored here for simplicity (deflated also works)
   const zipEntries = [
     { name: 'mimetype', data: mimetype, store: true },
     { name: 'META-INF/container.xml', data: containerXml, store: true },


### PR DESCRIPTION
epub_read_container and epub_read_opf now check the ZIP entry's compression field. Stored entries (method 0) are read synchronously as before. Deflated entries (method 8) use ward_decompress for async decompression, following the existing load_chapter pattern. The import chain Phase 3 is restructured to chain promises through container → OPF → add-book. No $UNSAFE constructs.