### PR TITLE
feat: escape key hierarchy (plan 4.7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,14 @@ sudo apt-get install -y clang lld
 - Function implementations in src/runtime.c (linked separately)
 - CI builds ATS2 from source with caching
 
+## Task Discipline
+
+Task list steps must be **extremely granular** — one file edit or one logical
+change per step. "Implement feature X" is an aspiration, not a step. Break it
+into steps like "Add absprop POSITION_SAVED to library.sats" or "Change
+reader_get_toc_view_mode return type in reader.sats". Each step should be
+completable in under 2 minutes and verifiable in isolation.
+
 ## Protocol
 
 See quire-design.md §2 for bridge protocol (diff buffer layout, op codes, exports).

--- a/e2e/epub-reader.spec.js
+++ b/e2e/epub-reader.spec.js
@@ -2903,5 +2903,67 @@ test.describe('EPUB Reader E2E', () => {
     expect(errors).toEqual([]);
   });
 
+  test('escape key hierarchy: TOC → chrome → library', async ({ page }) => {
+    const errors = [];
+    page.on('pageerror', err => errors.push(err.message));
+
+    const epubBuffer = createEpub({ title: 'Escape Test', chapters: 2, paragraphsPerChapter: 4 });
+    await page.goto('/');
+    await page.waitForSelector('.library-list', { timeout: 15000 });
+
+    const vp = page.viewportSize();
+    const epubPath = join(SCREENSHOT_DIR, `escape-test-${vp.width}x${vp.height}.epub`);
+    writeFileSync(epubPath, epubBuffer);
+    await page.locator('input[type="file"]').setInputFiles(epubPath);
+    await page.waitForSelector('.book-card', { timeout: 30000 });
+    await page.locator('.read-btn').click();
+    await page.waitForSelector('.reader-viewport', { timeout: 15000 });
+    await page.waitForFunction(() => {
+      const el = document.querySelector('.chapter-container');
+      return el && el.textContent && el.textContent.length > 50;
+    }, { timeout: 15000 });
+
+    // Wait for auto-hide timer to expire, then toggle chrome on via center tap
+    await page.waitForTimeout(6000);
+    await expect(page.locator('.reader-nav')).toBeHidden();
+
+    const viewport = page.viewportSize();
+    const centerX = viewport.width / 2;
+    const centerY = viewport.height / 2;
+    await page.mouse.click(centerX, centerY);
+    await page.waitForTimeout(500);
+    await expect(page.locator('.reader-nav')).toBeVisible();
+    await screenshot(page, 'escape-01-chrome-visible');
+
+    // Open TOC panel
+    await page.locator('.toc-btn').click();
+    await page.waitForTimeout(500);
+    await expect(page.locator('.toc-panel')).toBeVisible();
+    await screenshot(page, 'escape-02-toc-open');
+
+    // Escape 1: closes TOC, still in reader with chrome visible
+    await page.locator('.reader-viewport').focus();
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(500);
+    await expect(page.locator('.toc-panel')).toBeHidden();
+    await expect(page.locator('.reader-nav')).toBeVisible();
+    await screenshot(page, 'escape-03-toc-closed');
+
+    // Escape 2: hides chrome, still in reader
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(500);
+    await expect(page.locator('.reader-nav')).toBeHidden();
+    await expect(page.locator('.reader-viewport')).toBeAttached();
+    await screenshot(page, 'escape-04-chrome-hidden');
+
+    // Escape 3: exits to library
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(1000);
+    await expect(page.locator('.book-card')).toBeVisible();
+    await screenshot(page, 'escape-05-library');
+
+    expect(errors).toEqual([]);
+  });
+
 
 });

--- a/plan.md
+++ b/plan.md
@@ -175,7 +175,7 @@ everything else depends on.
   persistent "back" affordance pops the stack, returning to the exact prior
   position. Stack stored in reader state (not persisted across sessions).
 
-- [ ] **4.7 Escape key hierarchy.** Escape key follows the UI stack: close
+- [x] **4.7 Escape key hierarchy.** Escape key follows the UI stack: close
   footnote popup → close TOC/settings/search panel → hide chrome → return to
   library. Each press pops one layer. This is also the Android hardware back
   button behavior in the Capacitor shell.

--- a/src/library.dats
+++ b/src/library.dats
@@ -320,14 +320,18 @@ in
   else _app_lib_books_set_i32(index * REC_INTS + LAST_OPENED_SLOT, ts)
 end
 
+local
+  assume POSITION_SAVED() = unit_p
+in
 implement library_update_position(index, chapter, page) =
-  if lt_int_int(index, 0) then ()
-  else if gte_int_int(index, _app_lib_count()) then ()
+  if lt_int_int(index, 0) then (unit_p() | ())
+  else if gte_int_int(index, _app_lib_count()) then (unit_p() | ())
   else let
     val base = index * REC_INTS
     val () = _app_lib_books_set_i32(base + CHAPTER_SLOT, chapter)
     val () = _app_lib_books_set_i32(base + PAGE_SLOT, page)
-  in end
+  in (unit_p() | ()) end
+end (* local POSITION_SAVED *)
 
 implement library_find_book_by_id() = let
   val count = _app_lib_count()

--- a/src/library.sats
+++ b/src/library.sats
@@ -231,6 +231,14 @@ dataprop ADD_BOOK_RESULT(idx: int) =
   | {i:nat | i < 32} BOOK_ADDED(i)      (* success: book at index i *)
   | LIB_FULL(~1)                          (* library at 32-book capacity *)
 
+(* POSITION_SAVED(): proves library_update_position was called before reader_exit.
+ * absprop: unforgeable outside library.dats local assume block.
+ * Proves the function was called (not that data was written — when index is
+ * out of range no book is loaded, so no save is needed and the proof is
+ * legitimately granted).
+ * BUG CLASS PREVENTED: reader_exit called without calling library_update_position. *)
+absprop POSITION_SAVED()
+
 (* ========== Module Functions ========== *)
 
 fun library_init(): void
@@ -249,7 +257,7 @@ fun library_set_shelf_state {s:int}
 
 fun library_add_book(): [i:int | i >= ~1; i < 32] (ADD_BOOK_RESULT(i) | int(i))
 fun library_remove_book(index: int): void
-fun library_update_position(index: int, chapter: int, page: int): void
+fun library_update_position(index: int, chapter: int, page: int): (POSITION_SAVED() | void)
 fun library_find_book_by_id(): [i:int | i >= ~1] int(i)
 
 (* Replace an existing book entry with new epub data.

--- a/src/quire.dats
+++ b/src/quire.dats
@@ -577,7 +577,7 @@ in
  * library_update_position + library_save were called.
  * Bug class prevented: adding a navigation path that skips save. *)
 fn save_reading_position(): (POSITION_PERSISTED() | void) = let
-  val () = library_update_position(
+  val (_pf_saved | ()) = library_update_position(
     reader_get_book_index(),
     reader_get_current_chapter(),
     reader_get_current_page())
@@ -616,19 +616,9 @@ fn page_turn_backward(container_id: int)
   prval pf_pg = PAGE_TURNED_AND_SHOWN(pf_pg_info)
 in @(pf_pg, pf_pos | ()) end
 
-(* Save reading position and exit reader.
- * Constructs POSITION_SAVED proof required by reader_exit.
- * This is THE only permitted way to exit the reader from ATS code.
- * See POSITION_SAVED dataprop in reader.sats. *)
-fn reader_save_and_exit(): void = let
-  val () = library_update_position(
-    reader_get_book_index(),
-    reader_get_current_chapter(),
-    reader_get_current_page())
-  prval pf = SAVED()
-in
-  reader_exit(pf)
-end
+(* reader_save_and_exit removed: callers now call library_update_position
+ * directly and receive POSITION_SAVED proof from its return value.
+ * See POSITION_SAVED absprop in library.sats. *)
 
 (* Apply resume page after chapter loads.
  * If reader_get_resume_page() > 0, go to that page (clamped to total),
@@ -1456,65 +1446,6 @@ fn load_bookmarks_from_idb(): void = let
   val () = ward_promise_discard<int>(p2)
 in end
 
-(* ========== Reader keyboard handler ========== *)
-
-fn on_reader_keydown(payload_len: int, root_id: int): void = let
-  val pl = g1ofg0(payload_len)
-in
-  (* Keydown payload: [u8:keyLen][bytes:key][u8:flags]
-   * Minimum payload sizes: Space=3, Escape=8, ArrowLeft=11, ArrowRight=12 *)
-  if gt1_int_int(pl, 2) then let
-    val payload = ward_event_get_payload(pl)
-    val key_len = byte2int0(ward_arr_get<byte>(payload, 0))
-    val k0 = byte2int0(ward_arr_get<byte>(payload, 1))
-    val () = ward_arr_free<byte>(payload)
-    val cid = reader_get_container_id()
-  in
-    if eq_int_int(key_len, 6) then
-      (* "Escape": key_len=6, k0='E' (69) *)
-      if eq_int_int(k0, 69) then let
-        val () = reader_save_and_exit()
-        val () = render_library(root_id)
-      in end
-      else ()
-    else if eq_int_int(key_len, 10) then
-      (* "ArrowRight": key_len=10, k0='A' (65) *)
-      if eq_int_int(k0, 65) then let
-        val () = navigate_next(cid)
-        val () = auto_hide_chrome_on_turn()
-      in end
-      else ()
-    else if eq_int_int(key_len, 9) then
-      (* "ArrowLeft": key_len=9, k0='A' (65) *)
-      if eq_int_int(k0, 65) then let
-        val () = navigate_prev(cid)
-        val () = auto_hide_chrome_on_turn()
-      in end
-      else ()
-    else if eq_int_int(key_len, 1) then
-      (* " " (Space): key_len=1, k0=' ' (32) *)
-      if eq_int_int(k0, 32) then let
-        val () = navigate_next(cid)
-        val () = auto_hide_chrome_on_turn()
-      in end
-      (* 't' (116) or 'T' (84): toggle chrome *)
-      else if eq_int_int(k0, 116) then toggle_chrome()
-      else if eq_int_int(k0, 84) then toggle_chrome()
-      (* 'b' (98) or 'B' (66): toggle bookmark *)
-      else if eq_int_int(k0, 98) then let
-        val (pf | ()) = toggle_bookmark()
-        prval _ = pf
-      in end
-      else if eq_int_int(k0, 66) then let
-        val (pf | ()) = toggle_bookmark()
-        prval _ = pf
-      in end
-      else ()
-    else ()
-  end
-  else ()
-end
-
 (* ========== Scrubber helpers ========== *)
 
 (* Compute target page from pointer X position on track.
@@ -1806,38 +1737,59 @@ in
   in end
 end
 
-(* Hide the TOC panel and reset view mode to 0. *)
-fn hide_toc_panel(): void = let
-  val panel_id = reader_get_toc_panel_id()
+local
+  assume TOC_STATE(b) = unit_p
 in
-  if gt_int_int(panel_id, 0) then let
-    val () = reader_set_toc_view_mode(0)
-    val () = set_style_none(panel_id)
-  in end
-  else ()
-end
+
+(* show_toc_panel: sole constructor of TOC_STATE(true).
+ * Atomically sets toc_view_mode=1 (Contents), shows panel DOM, updates BM count. *)
+fn show_toc_panel(): (TOC_STATE(true) | void) = let
+  val panel_id = reader_get_toc_panel_id()
+  val () = reader_set_toc_view_mode(TOC_MODE_CONTENTS() | 1)
+  val () = if gt_int_int(panel_id, 0) then set_style_flex(panel_id) else ()
+  val () = update_toc_bm_count_btn()
+in (unit_p() | ()) end
+
+(* witness_toc_visible: witnesses runtime TOC state for event handlers.
+ * Requires m > 0 (caller must have proved via gt1_int_int).
+ * Necessary in event-driven code where proofs cannot be threaded through
+ * callback dispatch. *)
+fn witness_toc_visible{m:pos | m <= 2}
+  (pf_mode: TOC_VIEW_MODE_VALID(m) | mode: int(m)): (TOC_STATE(true) | void) = let
+  prval _ = pf_mode
+in (unit_p() | ()) end
+
+(* hide_toc_panel: consumes TOC_STATE(true), produces TOC_STATE(false).
+ * ALWAYS resets toc_view_mode to 0 — fixes state inconsistency bug where
+ * stale mode=1 with no panel_id caused silent no-ops on future Escape presses. *)
+fn hide_toc_panel(pf: TOC_STATE(true) | ): (TOC_STATE(false) | void) = let
+  prval unit_p() = pf
+  val panel_id = reader_get_toc_panel_id()
+  val () = reader_set_toc_view_mode(TOC_MODE_HIDDEN() | 0)
+  val () = if gt_int_int(panel_id, 0) then set_style_none(panel_id) else ()
+in (unit_p() | ()) end
+
+end (* local TOC_STATE *)
 
 (* Toggle TOC panel: show Contents if hidden, hide if visible. *)
 fn toggle_toc_panel(): void = let
-  val mode = reader_get_toc_view_mode()
-  val panel_id = reader_get_toc_panel_id()
+  val (pf_mode | mode) = reader_get_toc_view_mode()
 in
-  if eq_int_int(mode, 0) then let
-    (* Currently hidden: show Contents view *)
-    val () = reader_set_toc_view_mode(1)
-    val () = if gt_int_int(panel_id, 0) then set_style_flex(panel_id) else ()
-    val () = update_toc_bm_count_btn()
+  if gt1_int_int(mode, 0) then let
+    val (pf_open | ()) = witness_toc_visible(pf_mode | mode)
+    val (pf_closed | ()) = hide_toc_panel(pf_open | )
+    prval _ = pf_closed
   in end
   else let
-    (* Currently visible: hide *)
-    val () = reader_set_toc_view_mode(0)
-    val () = if gt_int_int(panel_id, 0) then set_style_none(panel_id) else ()
+    prval _ = pf_mode
+    val (pf_shown | ()) = show_toc_panel()
+    prval _ = pf_shown
   in end
 end
 
 (* Switch TOC panel to Bookmarks view. *)
 fn switch_toc_to_bm(): void = let
-  val () = reader_set_toc_view_mode(2)
+  val () = reader_set_toc_view_mode(TOC_MODE_BOOKMARKS() | 2)
   val () = clear_toc_list()
   val () = render_bm_entries()
   val switch_id = reader_get_toc_switch_btn_id()
@@ -1870,7 +1822,7 @@ end
 
 (* Switch TOC panel to Contents view. *)
 fn switch_toc_to_contents(): void = let
-  val () = reader_set_toc_view_mode(1)
+  val () = reader_set_toc_view_mode(TOC_MODE_CONTENTS() | 1)
   val () = clear_toc_list()
   val spine = epub_get_chapter_count()
   val () = render_toc_entries(spine)
@@ -1903,61 +1855,161 @@ in
   else ()
 end
 
-(* Handle click on a TOC list entry (event delegation by node ID offset). *)
+(* Handle click on a TOC list entry (event delegation by node ID offset).
+ * Uses check_toc_open for proof-carrying dispatch. *)
 fn on_toc_list_click(clicked_id: int): void = let
-  val mode = reader_get_toc_view_mode()
+  val (pf_mode | mode) = reader_get_toc_view_mode()
 in
-  if eq_int_int(mode, 1) then let
-    (* Contents mode: navigate to the clicked chapter *)
-    val first_id = reader_get_toc_first_entry_id()
-    val idx = clicked_id - first_id
-    val total = reader_get_chapter_count()
-    val total_g1 = g1ofg0(total)
-    val idx_g1 = g1ofg0(idx)
-    val () = if idx_g1 >= 0 then
-      if lt1_int_int(idx_g1, total_g1) then let
-        val (pf_pushed | ()) = push_position()
-        prval _ = pf_pushed
-        val () = reader_go_to_chapter(idx_g1, total_g1)
-        val () = hide_toc_panel()
-        val container_id = reader_get_container_id()
-        prval pf = SPINE_ENTRY()
-        val dom = ward_dom_init()
-        val s = ward_dom_stream_begin(dom)
-        val s = ward_dom_stream_remove_children(s, container_id)
-        val dom = ward_dom_stream_end(s)
-        val () = ward_dom_fini(dom)
-        val () = load_chapter_from_idb(pf | idx_g1, total_g1, container_id)
-      in () end
-      else ()
-    else ()
-  in end
-  else if eq_int_int(mode, 2) then let
-    (* Bookmarks mode: navigate to the clicked bookmark *)
-    val first_id = reader_get_bm_first_entry_id()
-    val idx = clicked_id - first_id
-    val cnt = reader_get_bm_count()
-    val idx_g1 = g1ofg0(idx)
-    val () = if idx_g1 >= 0 then
-      if lt_int_int(idx, cnt) then let
-        val base = idx * 3
-        val ch = _app_bm_buf_get_i32(base)
-        val pg = _app_bm_buf_get_i32(base + 1)
+  if gt1_int_int(mode, 0) then let
+    val (pf_open | ()) = witness_toc_visible(pf_mode | mode)
+    val (pf_mode2 | mode2) = reader_get_toc_view_mode()
+    prval _ = pf_mode2
+    val raw = g0ofg1(mode2)
+      val () = if eq_int_int(raw, 1) then let
+        (* Contents mode: navigate to the clicked chapter *)
+        val first_id = reader_get_toc_first_entry_id()
+        val idx = clicked_id - first_id
         val total = reader_get_chapter_count()
         val total_g1 = g1ofg0(total)
-        val ch_g1 = g1ofg0(ch)
-        val () = if ch_g1 >= 0 then
-          if lt1_int_int(ch_g1, total_g1) then let
-            val () = reader_go_to_chapter(ch_g1, total_g1)
-            val () = reader_set_resume_page(pg)
-            val () = hide_toc_panel()
+        val idx_g1 = g1ofg0(idx)
+        val () = if idx_g1 >= 0 then
+          if lt1_int_int(idx_g1, total_g1) then let
+            val (pf_pushed | ()) = push_position()
+            prval _ = pf_pushed
+            val () = reader_go_to_chapter(idx_g1, total_g1)
+            val container_id = reader_get_container_id()
+            prval pf_spine = SPINE_ENTRY()
+            val dom = ward_dom_init()
+            val s = ward_dom_stream_begin(dom)
+            val s = ward_dom_stream_remove_children(s, container_id)
+            val dom = ward_dom_stream_end(s)
+            val () = ward_dom_fini(dom)
+            val () = load_chapter_from_idb(pf_spine | idx_g1, total_g1, container_id)
+          in () end
+          else ()
+        else ()
+      in () end
+      else if eq_int_int(raw, 2) then let
+        (* Bookmarks mode: navigate to the clicked bookmark *)
+        val first_id = reader_get_bm_first_entry_id()
+        val idx = clicked_id - first_id
+        val cnt = reader_get_bm_count()
+        val idx_g1 = g1ofg0(idx)
+        val () = if idx_g1 >= 0 then
+          if lt_int_int(idx, cnt) then let
+            val base = idx * 3
+            val ch = _app_bm_buf_get_i32(base)
+            val pg = _app_bm_buf_get_i32(base + 1)
+            val total = reader_get_chapter_count()
+            val total_g1 = g1ofg0(total)
+            val ch_g1 = g1ofg0(ch)
+            val () = if ch_g1 >= 0 then
+              if lt1_int_int(ch_g1, total_g1) then let
+                val () = reader_go_to_chapter(ch_g1, total_g1)
+                val () = reader_set_resume_page(pg)
+              in () end
+              else ()
+            else ()
           in () end
           else ()
         else ()
       in () end
       else ()
-    else ()
+      (* hide_toc_panel called once, after all navigation logic *)
+      val (pf_closed | ()) = hide_toc_panel(pf_open | )
+      prval _ = pf_closed
+    in () end
+  else let
+    prval _ = pf_mode
+  in () end
+end
+
+(* handle_escape: pop one UI layer per Escape press.
+ * 1. TOC open → close TOC
+ * 2. Chrome visible → hide chrome + cancel timer
+ * 3. Neither → save position + exit to library
+ * Individual function calls (hide_toc_panel, hide_chrome, reader_exit)
+ * enforce their own proof requirements. *)
+fn handle_escape(root_id: int): void = let
+  val (pf_mode | mode) = reader_get_toc_view_mode()
+in
+  if gt1_int_int(mode, 0) then let
+    val (pf_open | ()) = witness_toc_visible(pf_mode | mode)
+    val (pf_closed | ()) = hide_toc_panel(pf_open | )
+    prval _ = pf_closed
   in end
+  else let
+    prval _ = pf_mode
+    val chrome_vis = reader_get_chrome_visible()
+  in
+    if eq_int_int(chrome_vis, 1) then let
+      val () = hide_chrome()
+      val _ = reader_incr_chrome_timer_gen()
+    in end
+    else let
+      val (pf_saved | ()) = library_update_position(
+        reader_get_book_index(),
+        reader_get_current_chapter(),
+        reader_get_current_page())
+      val () = reader_exit(pf_saved)
+      val () = render_library(root_id)
+    in end
+  end
+end
+
+(* ========== Reader keyboard handler ========== *)
+
+fn on_reader_keydown(payload_len: int, root_id: int): void = let
+  val pl = g1ofg0(payload_len)
+in
+  (* Keydown payload: [u8:keyLen][bytes:key][u8:flags]
+   * Minimum payload sizes: Space=3, Escape=8, ArrowLeft=11, ArrowRight=12 *)
+  if gt1_int_int(pl, 2) then let
+    val payload = ward_event_get_payload(pl)
+    val key_len = byte2int0(ward_arr_get<byte>(payload, 0))
+    val k0 = byte2int0(ward_arr_get<byte>(payload, 1))
+    val () = ward_arr_free<byte>(payload)
+    val cid = reader_get_container_id()
+  in
+    if eq_int_int(key_len, 6) then
+      (* "Escape": key_len=6, k0='E' (69) — pop one UI layer *)
+      if eq_int_int(k0, 69) then handle_escape(root_id)
+      else ()
+    else if eq_int_int(key_len, 10) then
+      (* "ArrowRight": key_len=10, k0='A' (65) *)
+      if eq_int_int(k0, 65) then let
+        val () = navigate_next(cid)
+        val () = auto_hide_chrome_on_turn()
+      in end
+      else ()
+    else if eq_int_int(key_len, 9) then
+      (* "ArrowLeft": key_len=9, k0='A' (65) *)
+      if eq_int_int(k0, 65) then let
+        val () = navigate_prev(cid)
+        val () = auto_hide_chrome_on_turn()
+      in end
+      else ()
+    else if eq_int_int(key_len, 1) then
+      (* " " (Space): key_len=1, k0=' ' (32) *)
+      if eq_int_int(k0, 32) then let
+        val () = navigate_next(cid)
+        val () = auto_hide_chrome_on_turn()
+      in end
+      (* 't' (116) or 'T' (84): toggle chrome *)
+      else if eq_int_int(k0, 116) then toggle_chrome()
+      else if eq_int_int(k0, 84) then toggle_chrome()
+      (* 'b' (98) or 'B' (66): toggle bookmark *)
+      else if eq_int_int(k0, 98) then let
+        val (pf | ()) = toggle_bookmark()
+        prval _ = pf
+      in end
+      else if eq_int_int(k0, 66) then let
+        val (pf | ()) = toggle_bookmark()
+        prval _ = pf
+      in end
+      else ()
+    else ()
+  end
   else ()
 end
 
@@ -2255,7 +2307,11 @@ implement enter_reader(root_id, book_index) = let
   val () = reader_add_event_listener(READER_LISTEN_BACK() |
     back_btn_id, evt_click(), 5, 31,
     lam (_pl: int): int => let
-      val () = reader_save_and_exit()
+      val (pf_saved | ()) = library_update_position(
+        reader_get_book_index(),
+        reader_get_current_chapter(),
+        reader_get_current_page())
+      val () = reader_exit(pf_saved)
       val () = render_library(saved_root)
     in 0 end
   )
@@ -2429,7 +2485,15 @@ implement enter_reader(root_id, book_index) = let
   val () = reader_add_event_listener(READER_LISTEN_TOC_CLOSE() |
     toc_close_btn_id, evt_click(), 5, 39,
     lam (_pl: int): int => let
-      val () = hide_toc_panel()
+      val (pf_mode | mode) = reader_get_toc_view_mode()
+      val () = if gt1_int_int(mode, 0) then let
+        val (pf_open | ()) = witness_toc_visible(pf_mode | mode)
+        val (pf_closed | ()) = hide_toc_panel(pf_open | )
+        prval _ = pf_closed
+      in () end
+      else let
+        prval _ = pf_mode
+      in () end
     in 0 end
   )
 
@@ -2445,9 +2509,11 @@ implement enter_reader(root_id, book_index) = let
   val () = reader_add_event_listener(READER_LISTEN_TOC_SWITCH() |
     toc_switch_btn_id, evt_click(), 5, 41,
     lam (_pl: int): int => let
-      val mode = reader_get_toc_view_mode()
-      val () = if eq_int_int(mode, 1) then switch_toc_to_bm()
-               else if eq_int_int(mode, 2) then switch_toc_to_contents()
+      val (pf_mode | mode) = reader_get_toc_view_mode()
+      prval _ = pf_mode
+      val raw = g0ofg1(mode)
+      val () = if eq_int_int(raw, 1) then switch_toc_to_bm()
+               else if eq_int_int(raw, 2) then switch_toc_to_contents()
                else ()
     in 0 end
   )

--- a/src/reader.dats
+++ b/src/reader.dats
@@ -55,7 +55,7 @@ implement reader_enter(root_id, container_hide_id) = let
 in end
 
 implement reader_exit(pf) = let
-  prval SAVED() = pf
+  prval _ = pf
   val st = app_state_load()
   val () = app_set_rdr_active(st, 0)
   val () = app_set_rdr_book_index(st, 0 - 1)
@@ -194,7 +194,10 @@ implement reader_remeasure_all() = ()
 implement reader_show_toc() = ()
 implement reader_hide_toc() = ()
 implement reader_toggle_toc() = ()
-implement reader_is_toc_visible() = gt_int_int(reader_get_toc_view_mode(), 0)
+implement reader_is_toc_visible() = let
+  val (pf_mode | mode) = reader_get_toc_view_mode()
+  prval _ = pf_mode
+in gt_int_int(mode, 0) end
 implement reader_get_toc_id() = 0
 implement reader_get_progress_bar_id() = 0
 implement reader_get_toc_index_for_node(node_id) = 0 - 1
@@ -552,7 +555,8 @@ implement reader_get_toc_switch_btn_id() = let
   val () = app_state_store(st)
 in v end
 
-implement reader_set_toc_view_mode(v) = let
+implement reader_set_toc_view_mode{m}(pf | v) = let
+  prval _ = pf
   val st = app_state_load()
   val () = app_set_rdr_toc_view_mode(st, v)
   val () = app_state_store(st)
@@ -562,7 +566,11 @@ implement reader_get_toc_view_mode() = let
   val st = app_state_load()
   val v = app_get_rdr_toc_view_mode(st)
   val () = app_state_store(st)
-in v end
+in
+  if eq_int_int(v, 1) then (TOC_MODE_CONTENTS() | 1)
+  else if eq_int_int(v, 2) then (TOC_MODE_BOOKMARKS() | 2)
+  else (TOC_MODE_HIDDEN() | 0)
+end
 
 implement reader_set_toc_first_entry_id(id) = let
   val st = app_state_load()

--- a/src/reader.sats
+++ b/src/reader.sats
@@ -15,6 +15,7 @@
 #define SLOT_READY    2
 
 staload "./drag_state.sats"
+staload "./library.sats"
 
 (* ========== M13: Functional Correctness Dataprops ========== *)
 
@@ -109,19 +110,9 @@ dataprop PAGE_IN_BOUNDS(page: int, total: int) =
 dataprop NAV_DIRECTION(d: int) =
   | NAV_PREV(~1) | NAV_NEXT(1)
 
-(* Position saved before exit proof.
- * POSITION_SAVED() proves that library_update_position was called
- * with the reader's current book_index, chapter, and page BEFORE
- * reader_exit clears reader state (book_index → -1, page → 0).
- *
- * Without this proof, reader_exit rejects at compile time.
- * The only way to construct SAVED() is at the call site where
- * library_update_position is textually adjacent — forcing the
- * developer to consciously save before exiting.
- *
- * BUG PREVENTED: reader_exit called without saving position,
- * causing library to show "Not started" after reading. *)
-dataprop POSITION_SAVED() = | SAVED()
+(* POSITION_SAVED: declared in library.sats as absprop.
+ * Produced only by library_update_position via local assume in library.dats.
+ * Required by reader_exit — unforgeable proof that position update was attempted. *)
 
 (* Named listener IDs — single source of truth.
  * Dataprop enum prevents arbitrary IDs in reader event listeners. *)
@@ -262,6 +253,13 @@ fun reader_get_scrub_drag_ch(): int
 
 (* ========== TOC panel state ========== *)
 
+(* TOC view mode: 0=hidden, 1=contents, 2=bookmarks.
+ * Proof required on set prevents arbitrary mode values. *)
+dataprop TOC_VIEW_MODE_VALID(m: int) =
+  | TOC_MODE_HIDDEN(0)
+  | TOC_MODE_CONTENTS(1)
+  | TOC_MODE_BOOKMARKS(2)
+
 fun reader_set_toc_panel_id(id: int): void
 fun reader_get_toc_panel_id(): int
 fun reader_set_toc_list_id(id: int): void
@@ -272,8 +270,8 @@ fun reader_set_toc_bm_count_btn_id(id: int): void
 fun reader_get_toc_bm_count_btn_id(): int
 fun reader_set_toc_switch_btn_id(id: int): void
 fun reader_get_toc_switch_btn_id(): int
-fun reader_set_toc_view_mode(v: int): void
-fun reader_get_toc_view_mode(): int
+fun reader_set_toc_view_mode{m:nat | m <= 2}(pf: TOC_VIEW_MODE_VALID(m) | v: int(m)): void
+fun reader_get_toc_view_mode(): [m:nat | m <= 2] (TOC_VIEW_MODE_VALID(m) | int(m))
 fun reader_set_toc_first_entry_id(id: int): void
 fun reader_get_toc_first_entry_id(): int
 fun reader_set_toc_entry_count(n: int): void


### PR DESCRIPTION
## Summary

- Escape key follows UI stack: close TOC panel → hide chrome → save position + exit to library
- Post-fanatic-review proof improvements:
  - `POSITION_SAVED` absprop in `library.sats`, produced by `library_update_position` via `local assume`
  - `TOC_VIEW_MODE_VALID` dataprop: `reader_set_toc_view_mode` requires proof, `reader_get_toc_view_mode` returns proof + bounded `int(m)` where `m <= 2`
  - `show_toc_panel` is sole constructor of `TOC_STATE(true)`; `witness_toc_visible` requires `{m:pos | m <= 2}` for event handlers
  - `hide_toc_panel` always resets `toc_view_mode` to 0 (fixes stale mode bug)
  - No `ESCAPE_ACTION` dataprop (fanatic review: unindexed enum proves nothing; individual function calls enforce their own proofs)

## Test plan

- [ ] CI builds ATS2 from source (type-checks all proofs)
- [ ] New e2e test: escape hierarchy (TOC → chrome → library) on all 5 viewports
- [ ] Existing e2e tests pass (TOC, chrome, bookmark, posstack)
- [ ] Visual check on all viewport screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)