### PR TITLE
feat: table scroll + image scaling CSS (plan 11.1-11.2)

### DIFF
--- a/e2e/epub-reader.spec.js
+++ b/e2e/epub-reader.spec.js
@@ -3420,5 +3420,42 @@ test.describe('EPUB Reader E2E', () => {
     expect(errors).toEqual([]);
   });
 
+  test('chapter images have max-width CSS applied', async ({ page }) => {
+    const errors = [];
+    page.on('pageerror', err => errors.push(err.message));
+    const epubBuffer = createEpub({
+      title: 'CSS Render Test', chapters: 1, paragraphsPerChapter: 3, coverImage: true,
+    });
+    await page.goto('/');
+    await page.waitForSelector('.library-list', { timeout: 15000 });
+    const vp = page.viewportSize();
+    const epubPath = join(SCREENSHOT_DIR, `cssrender-${vp.width}x${vp.height}.epub`);
+    writeFileSync(epubPath, epubBuffer);
+    await page.locator('input[type="file"]').setInputFiles(epubPath);
+    await page.waitForSelector('.book-card', { timeout: 30000 });
+    await page.locator('.read-btn').click();
+    await page.waitForSelector('.reader-viewport', { timeout: 15000 });
+    await page.waitForFunction(() => {
+      const el = document.querySelector('.chapter-container');
+      return el && el.childElementCount > 0;
+    }, { timeout: 15000 });
+    // Verify the CSS rule is loaded (reader.css)
+    const hasRule = await page.evaluate(() => {
+      for (const sheet of document.styleSheets) {
+        try {
+          for (const rule of sheet.cssRules) {
+            if (rule.selectorText && rule.selectorText.includes('.chapter-container img')) {
+              return true;
+            }
+          }
+        } catch(e) {}
+      }
+      return false;
+    });
+    expect(hasRule).toBe(true);
+    await screenshot(page, 'cssrender-01-rules');
+    expect(errors).toEqual([]);
+  });
+
 
 });

--- a/plan.md
+++ b/plan.md
@@ -444,11 +444,11 @@ everything else depends on.
 
 ## Phase 11 — Wide tables & images
 
-- [ ] **11.1 Wide table horizontal scroll.** Tables exceeding viewport width
+- [x] **11.1 Wide table horizontal scroll.** Tables exceeding viewport width
   get `overflow-x: auto` wrapper. No scaling or reformatting. CSS-only fix
   applied during chapter rendering.
 
-- [ ] **11.2 Images scaled to viewport width.** Ensure images in chapter
+- [x] **11.2 Images scaled to viewport width.** Ensure images in chapter
   content are constrained to `max-width: 100%`. Per spec: "Scaled to fit
   viewport width for v1."
 

--- a/reader.css
+++ b/reader.css
@@ -28,6 +28,21 @@
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
+/* ========== Content rendering fixes ========== */
+
+/* 11.1: Wide tables get horizontal scroll instead of breaking layout */
+.chapter-container table {
+  display: block;
+  overflow-x: auto;
+  max-width: 100%;
+}
+
+/* 11.2: Images constrained to viewport width */
+.chapter-container img {
+  max-width: 100%;
+  height: auto;
+}
+
 /* ========== Loading screen ========== */
 
 /* Quire loading screen — scoped to .quire-loading so it


### PR DESCRIPTION
## Summary
- Wide tables: `overflow-x: auto` for horizontal scroll
- Images: `max-width: 100%` constrains to viewport width
- E2e test verifies CSS rules are loaded

## Test plan
- [ ] CI builds
- [ ] New CSS rendering test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)