### PR TITLE
fix: R6 cap text column at 680px (no auto margins)

### DIFF
--- a/e2e/epub-reader.spec.js
+++ b/e2e/epub-reader.spec.js
@@ -2846,5 +2846,50 @@ test('bookmark toggle via button click and B key', async ({ page }) => {
     expect(errors).toEqual([]);
   });
 
+  test('R6: text line width capped on wide viewports', async ({ page }) => {
+    const errors = [];
+    page.on('pageerror', err => errors.push(err.message));
+    const epubBuffer = createEpub({ title: 'Width Cap Test', chapters: 1, paragraphsPerChapter: 5 });
+    await page.goto('/');
+    await page.waitForSelector('.library-list', { timeout: 15000 });
+    const vp = page.viewportSize();
+    const epubPath = join(SCREENSHOT_DIR, `r6-cap-${vp.width}x${vp.height}.epub`);
+    writeFileSync(epubPath, epubBuffer);
+    await page.locator('input[type="file"]').setInputFiles(epubPath);
+    await page.waitForSelector('.book-card', { timeout: 30000 });
+    await page.locator('.book-card').click();
+    await page.waitForSelector('.reader-viewport', { timeout: 15000 });
+    await page.waitForFunction(() => {
+      const el = document.querySelector('.chapter-container');
+      return el && el.childElementCount > 0;
+    }, { timeout: 15000 });
+    await page.waitForTimeout(1000);
+
+    // Measure actual text width of a paragraph
+    const textWidth = await page.evaluate(() => {
+      const p = document.querySelector('.chapter-container p');
+      if (!p) return null;
+      const rect = p.getBoundingClientRect();
+      return rect.width;
+    });
+    expect(textWidth).not.toBeNull();
+
+    // On wide viewports (>= 1024px), text width should be <= 720px
+    // (680px target + some tolerance for padding/box-sizing)
+    if (vp.width >= 1024) {
+      expect(textWidth).toBeLessThanOrEqual(720);
+    }
+
+    // Pagination must still work — should have multiple pages
+    if (vp.width >= 1024) {
+      const pageInfo = await page.locator('.page-info').textContent();
+      // Should NOT be "p. 1/1" on wide viewport with 5 paragraphs
+      // (unless content genuinely fits — 5 short paragraphs might fit)
+    }
+
+    await screenshot(page, 'r6-02-width-capped');
+    expect(errors).toEqual([]);
+  });
+
 
 });

--- a/reader.css
+++ b/reader.css
@@ -28,6 +28,19 @@
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
+/* R6: Cap text line width for comfortable reading on wide screens.
+ * max-width alone (no margin:auto) — avoids breaking CSS column pagination.
+ * Children stay left-aligned within the column; on narrow viewports (<680px)
+ * this has no effect. */
+.chapter-container > p,
+.chapter-container > h1,
+.chapter-container > h2,
+.chapter-container > h3,
+.chapter-container > blockquote,
+.chapter-container > pre {
+  max-width: 680px;
+}
+
 /* ========== Content rendering fixes ========== */
 
 /* 11.1: Wide tables get horizontal scroll instead of breaking layout */


### PR DESCRIPTION
max-width:680px on text elements in reader.css. No margin:auto — avoids column pagination break. E2e test verifies width <= 720px on wide viewports.