### PR TITLE
fix: R5 scrubber transparent background + divider

### DIFF
--- a/e2e/epub-reader.spec.js
+++ b/e2e/epub-reader.spec.js
@@ -2891,5 +2891,37 @@ test('bookmark toggle via button click and B key', async ({ page }) => {
     expect(errors).toEqual([]);
   });
 
+  test('R5: scrubber background is not dark overlay', async ({ page }) => {
+    const errors = [];
+    page.on('pageerror', err => errors.push(err.message));
+    const epubBuffer = createEpub({ title: 'Scrub BG Test', chapters: 2, paragraphsPerChapter: 5 });
+    await page.goto('/');
+    await page.waitForSelector('.library-list', { timeout: 15000 });
+    const vp = page.viewportSize();
+    const epubPath = join(SCREENSHOT_DIR, `r5-bg-${vp.width}x${vp.height}.epub`);
+    writeFileSync(epubPath, epubBuffer);
+    await page.locator('input[type="file"]').setInputFiles(epubPath);
+    await page.waitForSelector('.book-card', { timeout: 30000 });
+    await page.locator('.book-card').click();
+    await page.waitForSelector('.reader-viewport', { timeout: 15000 });
+    await page.waitForFunction(() => {
+      const el = document.querySelector('.chapter-container');
+      return el && el.childElementCount > 0;
+    }, { timeout: 15000 });
+    await page.waitForTimeout(1000);
+
+    // Scrubber bottom bar should NOT have dark background
+    const bg = await page.evaluate(() => {
+      const bottom = document.querySelector('.reader-bottom');
+      if (!bottom) return null;
+      return getComputedStyle(bottom).backgroundColor;
+    });
+    expect(bg).not.toBeNull();
+    // Should not be dark rgba(0,0,0,...) with alpha > 0.1
+    expect(bg).not.toMatch(/rgba\(0,\s*0,\s*0,\s*0\.[2-9]/);
+    await screenshot(page, 'r5-02-light-scrubber');
+    expect(errors).toEqual([]);
+  });
+
 
 });

--- a/reader.css
+++ b/reader.css
@@ -28,6 +28,12 @@
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
+/* R5: Scrubber divider — transparent bg lets page background show through,
+ * border-top provides subtle visual separation. */
+.reader-bottom {
+  border-top: 1px solid #e0e0e0;
+}
+
 /* R6: Cap text line width for comfortable reading on wide screens.
  * max-width alone (no margin:auto) — avoids breaking CSS column pagination.
  * Children stay left-aligned within the column; on narrow viewports (<680px)

--- a/src/quire_css.dats
+++ b/src/quire_css.dats
@@ -1223,7 +1223,7 @@ fn fill_scrub_all {l:agz}
   val () = _w4(arr, alen, 128, 1633838962)
   val () = _w4(arr, alen, 132, 808202280)
   val () = _w4(arr, alen, 136, 774647852)
-  val () = _w4(arr, alen, 140, 779954487)
+  val () = _w4(arr, alen, 140, 779954480)
   (* .scrubber{position:relative;height:24px;display:flex;align-items:center;
    * touch-action:none} *)
   val () = _w4(arr, alen, 144, 1970430835)


### PR DESCRIPTION
rgba(0,0,0,.7)→rgba(0,0,0,.0). Page bg shows through. Border-top divider in reader.css. E2e verifies.