### PR TITLE
fix: correct service worker cache name in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,6 @@ dist: build/quire.wasm
 	cp icon-512.png dist/ 2>/dev/null || true
 	sed -i "s|./vendor/ward/lib/ward_bridge.mjs|./ward_bridge.js|" dist/index.html
 	sed -i "s|>dev</div>|>$(COMMIT_SHA)</div>|" dist/index.html
-	sed -i "s|quire-v3|quire-$(COMMIT_SHA)|" dist/service-worker.js
+	sed -i "s|quire-v4|quire-$(COMMIT_SHA)|" dist/service-worker.js
 
 .PHONY: all clean install dist static-tests


### PR DESCRIPTION
## Summary
- Makefile `sed` command looked for `quire-v3` but `service-worker.js` has `quire-v4`
- Result: cache name never got stamped with commit SHA on deploy
- Every deployment reused the same `quire-v4` cache — stale WASM, HTML, etc.

## Test plan
- [ ] CI green
- [ ] After deploy, verify service worker uses `quire-<sha>` cache name (not `quire-v4`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)