### PR TITLE
fix: fold search query to lowercase before matching

### DIFF
--- a/e2e/epub-reader.spec.js
+++ b/e2e/epub-reader.spec.js
@@ -2662,8 +2662,8 @@ test('bookmark toggle via button click and B key', async ({ page }) => {
     const searchInput = searchPanel.locator('input[type="text"]');
     await expect(searchInput).toBeAttached();
 
-    // Type "mountain" — appears in generated EPUB paragraphs
-    await searchInput.fill('mountain');
+    // Type "Mountain" (capital M) — tests case-insensitive search
+    await searchInput.fill('Mountain');
     // Trigger change event (fill doesn't always fire change)
     await searchInput.dispatchEvent('change');
     // Wait for async IDB search to complete

--- a/src/quire.dats
+++ b/src/quire.dats
@@ -3284,6 +3284,24 @@ implement enter_reader(root_id, book_index) = let
       val raw_ptr = $UN.castvwtp1{ptr}(query_arr)
       val query_len = quire_get_input_value(saved_search_input,
         $UN.cast{int}(raw_ptr), 256)
+      (* Fold query to lowercase — search index text is lowercased during indexing.
+       * Without this, queries with uppercase letters find no matches. *)
+      val qmem = $UN.cast{ptr}(raw_ptr)
+      fun fold_query {k:nat} .<k>.
+        (rem: int(k), i: int, p: ptr): void =
+        if lte_g1(rem, 0) then ()
+        else let
+          val b = byte2int0($UN.ptr0_get<byte>(ptr_add<byte>(p, i)))
+        in
+          if gte_int_int(b, 65) then
+            if lte_int_int(b, 90) then let
+              val () = $UN.ptr0_set<byte>(ptr_add<byte>(p, i), ward_int2byte(_checked_byte(b + 32)))
+            in fold_query(sub_g1(rem, 1), i + 1, p) end
+            else fold_query(sub_g1(rem, 1), i + 1, p)
+          else fold_query(sub_g1(rem, 1), i + 1, p)
+        end
+      val () = if gt_int_int(query_len, 0) then
+        fold_query(_checked_nat(query_len), 0, qmem) else ()
     in
       if gt_int_int(query_len, 0) then let
         val spine_count = reader_get_chapter_count()


### PR DESCRIPTION
## Summary
- Search index text is lowercased at build time, but query was compared as-is
- Any uppercase character in the query would cause zero matches
- Now folds ASCII A-Z → a-z in the query before byte comparison
- E2e test uses 'Mountain' (capital M) to verify case-insensitive search

Note: if search doesn't work at all (even lowercase), the most likely cause is
the stale service worker cache (#129) — books imported with old WASM have no
search index. Re-importing after cache bust should fix it.

## Test plan
- [ ] CI green — e2e search test uses 'Mountain' and still finds results
- [ ] Manual test: search with uppercase query finds matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)