### PR TITLE
fix: Android APK ships real WASM instead of empty file

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+env:
+  ATS_VERSION: "0.4.2"
+
 jobs:
   build-android:
     runs-on: ubuntu-latest
@@ -13,13 +16,40 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 21
+
+      - name: Cache ATS2 toolchain
+        id: cache-ats
+        uses: actions/cache@v4
+        with:
+          path: ~/ATS2-Postiats-int-${{ env.ATS_VERSION }}
+          key: ats2-int-${{ env.ATS_VERSION }}-${{ runner.os }}
+
+      - name: Download and build ATS2
+        if: steps.cache-ats.outputs.cache-hit != 'true'
+        run: |
+          curl -sL "https://raw.githubusercontent.com/ats-lang/ats-lang.github.io/master/FROZEN000/ATS-Postiats/ATS2-Postiats-int-${{ env.ATS_VERSION }}.tgz" -o /tmp/ats2.tgz
+          tar -xzf /tmp/ats2.tgz -C ~
+          cd ~/ATS2-Postiats-int-${{ env.ATS_VERSION }}
+          ./configure
+          make -j$(nproc) -C src/CBOOT patsopt
+
+      - name: Install WASM toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang lld
+
+      - name: Build quire.wasm
+        run: |
+          export PATSHOME=$HOME/ATS2-Postiats-int-${{ env.ATS_VERSION }}
+          make PATSOPT="PATSHOME=$PATSHOME $PATSHOME/src/CBOOT/patsopt"
+          test -f build/quire.wasm
 
       - name: Install dependencies
         run: npm ci
@@ -33,7 +63,7 @@ jobs:
           cp index.html reader.css manifest.json service-worker.js dist/
           cp -r assets/fonts/* dist/assets/fonts/ 2>/dev/null || true
           cp vendor/ward/lib/ward_bridge.mjs dist/vendor/ward/lib/
-          touch dist/quire.wasm
+          cp build/quire.wasm dist/quire.wasm
 
       - name: Add Android platform
         run: npx cap add android


### PR DESCRIPTION
## Summary

- The Android workflow was using `touch dist/quire.wasm` which produced a 0-byte file
- The APK loaded but showed an infinite spinner because the empty WASM couldn't be instantiated
- Now builds WASM from source using the same ATS2 toolchain + cache as `pr.yaml`

## Test plan
- [ ] CI Android Build job passes (builds real WASM + APK)
- [ ] Install APK on device — app loads past the spinner and shows the library

🤖 Generated with [Claude Code](https://claude.com/claude-code)