### PR TITLE
fix: Android status bar overlapping nav buttons

### DIFF
--- a/capacitor.config.json
+++ b/capacitor.config.json
@@ -4,5 +4,10 @@
   "webDir": "dist",
   "server": {
     "androidScheme": "https"
+  },
+  "plugins": {
+    "StatusBar": {
+      "overlaysWebView": false
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@capacitor/android": "^8.1.0",
-        "@capacitor/core": "^8.1.0"
+        "@capacitor/core": "^8.1.0",
+        "@capacitor/status-bar": "^8.0.1"
       },
       "devDependencies": {
         "@playwright/test": "^1.56.0",
@@ -49,6 +50,15 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@capacitor/status-bar": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/status-bar/-/status-bar-8.0.1.tgz",
+      "integrity": "sha512-OR59dlbwvmrV5dKsC9lvwv48QaGbqcbSTBpk+9/WXWxXYSdXXdzJZU9p8oyNPAkuJhCdnSa3XmU43fZRPBJJ5w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@csstools/color-helpers": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@capacitor/android": "^8.1.0",
-    "@capacitor/core": "^8.1.0"
+    "@capacitor/core": "^8.1.0",
+    "@capacitor/status-bar": "^8.0.1"
   }
 }


### PR DESCRIPTION
## Summary
- Install `@capacitor/status-bar` plugin
- Set `overlaysWebView: false` in capacitor.config.json
- CSS `env(safe-area-inset-top)` doesn't work in Android WebView — the native plugin is needed

## Test plan
- [ ] CI green
- [ ] Install APK — nav buttons no longer collide with Android status bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)