### PR TITLE
fix: Android 15+ status bar overlap via adjustMarginsForEdgeToEdge

### DIFF
--- a/capacitor.config.json
+++ b/capacitor.config.json
@@ -5,6 +5,9 @@
   "server": {
     "androidScheme": "https"
   },
+  "android": {
+    "adjustMarginsForEdgeToEdge": "auto"
+  },
   "plugins": {
     "StatusBar": {
       "overlaysWebView": false


### PR DESCRIPTION
## Summary
- Android 15+ enforces edge-to-edge, making `overlaysWebView: false` ineffective
- Add `adjustMarginsForEdgeToEdge: "auto"` to the `android` config section
- This tells Capacitor to auto-add margins for system bars

## Context
- [Capacitor issue #8093](https://github.com/ionic-team/capacitor/issues/8093) — `overlaysWebView` bug on Android 15
- [Ionic Forum thread](https://forum.ionicframework.com/t/status-bar-overlaps-the-app-content-help/247967)

## Test plan
- [ ] CI green
- [ ] Install APK on Android 15+ — nav buttons below status bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)