### PR TITLE
fix: block EPUB style elements from rendering

### DIFF
--- a/e2e/epub-reader.spec.js
+++ b/e2e/epub-reader.spec.js
@@ -3201,4 +3201,54 @@ test('bookmark toggle via button click and B key', async ({ page }) => {
     expect(errors).toEqual([]);
   });
 
+  test('EPUB style elements are blocked from rendering', async ({ page }) => {
+    const errors = [];
+    page.on('pageerror', err => errors.push(err.message));
+
+    // Create EPUB with a <style> element that would set green background
+    const epubBuffer = createEpub({
+      title: 'Style Block Test',
+      rawChapters: [{
+        body: '<style>body{background-color:green !important}div{background-color:green !important}</style><h1>Style Test</h1><p>This chapter contains a style element that should be blocked.</p>',
+      }],
+    });
+
+    await page.goto('/');
+    await page.waitForSelector('.library-list', { timeout: 15000 });
+    const vp = page.viewportSize();
+    const epubPath = join(SCREENSHOT_DIR, `style-block-${vp.width}x${vp.height}.epub`);
+    writeFileSync(epubPath, epubBuffer);
+    await page.locator('input[type="file"]').setInputFiles(epubPath);
+    await page.waitForSelector('.book-card', { timeout: 30000 });
+    await page.locator('.book-card').click();
+    await page.waitForSelector('.reader-viewport', { timeout: 15000 });
+    await page.waitForFunction(() => {
+      const el = document.querySelector('.chapter-container');
+      return el && el.childElementCount > 0;
+    }, { timeout: 15000 });
+    await page.waitForTimeout(500);
+
+    // Verify no element has green background from the EPUB's <style>
+    const hasGreenBg = await page.evaluate(() => {
+      const allElements = document.querySelectorAll('*');
+      for (const el of allElements) {
+        const bg = getComputedStyle(el).backgroundColor;
+        // green = rgb(0, 128, 0) or rgb(0,128,0)
+        if (bg === 'rgb(0, 128, 0)') return true;
+      }
+      return false;
+    });
+    expect(hasGreenBg).toBe(false);
+
+    // Verify the chapter content rendered (style element was skipped, not the whole chapter)
+    const hasContent = await page.evaluate(() => {
+      const h1 = document.querySelector('.chapter-container h1');
+      return h1 && h1.textContent.includes('Style Test');
+    });
+    expect(hasContent).toBe(true);
+
+    await screenshot(page, 'style-block-01-no-green');
+    expect(errors).toEqual([]);
+  });
+
 });

--- a/src/dom.dats
+++ b/src/dom.dats
@@ -1142,7 +1142,8 @@ implement render_tree{l}{lb}{n}(stream, parent_id, tree, tree_len) = let
         val after_attrs = skip_attrs(r1, tree, attr_off + 1, attr_count, tlen)
       in
         if tag_idx >= 0 then
-          if tag_idx = TAG_IDX_IMG then let
+          if tag_idx = TAG_IDX_IMG
+             || tag_idx = TAG_IDX_STYLE then let
             val end_pos = skip_element(r1, tree, after_attrs, len, tlen)
           in
             loop(r1, st, tree, end_pos, len, parent, tlen, has_child, ecnt)
@@ -1523,7 +1524,12 @@ implement render_tree_with_images
         val after_attrs = skip_attrs_img(r1, tree, attr_off + 1, attr_count, tlen)
       in
         if tag_idx >= 0 then
-          if tag_idx = TAG_IDX_IMG then let
+          if tag_idx = TAG_IDX_STYLE then let
+            val end_pos = skip_element_img(r1, tree, after_attrs, len, tlen)
+          in
+            loop(r1, st, tree, end_pos, len, parent, tlen, has_child, ecnt, fh, cdir, cdlen)
+          end
+          else if tag_idx = TAG_IDX_IMG then let
             val @(tag_st, tag_st_len) = get_tag_by_index(tag_idx)
             val nid = dom_next_id()
             val st = ward_dom_stream_create_element(st, nid, parent, tag_st, tag_st_len)

--- a/src/dom.sats
+++ b/src/dom.sats
@@ -170,8 +170,10 @@ fun attr_download(): ward_safe_text(8)
  * update these constants. Adding a new constructor is the ONLY
  * way to make a tag index skippable. *)
 dataprop SKIPPABLE_TAG(idx: int) =
+  | SKIP_STYLE(3)
   | SKIP_IMG(13)
 
+#define TAG_IDX_STYLE 3
 #define TAG_IDX_A 12
 #define TAG_IDX_IMG 13
 

--- a/src/static_tests.dats
+++ b/src/static_tests.dats
@@ -16,6 +16,7 @@ staload "./../vendor/ward/lib/memory.sats"
 staload "./drag_state.sats"
 staload "./reader.sats"
 staload "./quire_css.sats"
+staload "./dom.sats"
 
 (* Shared proof declarations — production types, not shadows.
  * Tests use these directly to verify proof structure. *)
@@ -997,3 +998,22 @@ fun test_gear_icon_valid(): bool(true) = let
   prval pf = GEAR_CP_OK()
   prval _ = pf : GEAR_ICON_VALID(0x2699)
 in true end
+
+(* ================================================================
+ * Test 36: SKIPPABLE_TAG — IMG and STYLE are skippable
+ *
+ * Verifies both SKIP_IMG(13) and SKIP_STYLE(3) constructors
+ * are satisfiable, and that the tag indices match their defines.
+ * ================================================================ *)
+
+(* UNIT TEST — SKIP_IMG is constructible at index 13 *)
+fun test_skip_img(): bool(true) = let
+  prval pf = SKIP_IMG()
+  prval _ = pf : SKIPPABLE_TAG(13)
+in eq_g1(TAG_IDX_IMG, 13) end
+
+(* UNIT TEST — SKIP_STYLE is constructible at index 3 *)
+fun test_skip_style(): bool(true) = let
+  prval pf = SKIP_STYLE()
+  prval _ = pf : SKIPPABLE_TAG(3)
+in eq_g1(TAG_IDX_STYLE, 3) end


### PR DESCRIPTION
## Summary
- EPUB `<style>` elements were being rendered as live stylesheets, allowing book CSS to override reader styling (e.g. green background)
- Added `SKIP_STYLE(3)` to `SKIPPABLE_TAG` dataprop and skip `<style>` in both `render_tree` and `render_tree_with_images`
- Added static unit tests proving SKIPPABLE_TAG covers both IMG and STYLE indices

## Test plan
- [x] `make` builds successfully
- [x] `npm test` bridge tests pass
- [x] e2e test: EPUB with `<style>body{background-color:green}</style>` imports, renders content, no green background detected via `getComputedStyle`
- [x] Visual check: all 5 viewports clean, no green, content renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)